### PR TITLE
Issue/439

### DIFF
--- a/src/directives/dynamic-choices.js
+++ b/src/directives/dynamic-choices.js
@@ -283,11 +283,13 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
 
         function setupWatch(watchKey) {
           scope.$watch('model' + watchKey, function(newVal, oldVal) {
-            if(newVal != oldVal) {
-              populateTitleMap(newVal).finally(
-                function() {scope.$emit('sf-changed-titlemap', form.key);}
-              );
-            }
+            // FYI - You might be tempted to put a if(newVal != oldVal) wrapper here.
+            // That would be a mistake. We rely on this watch to kick off the initial
+            // (on page load) populateTitleMap once all 'dependent' parameters are
+            // initialized.
+            populateTitleMap().finally(
+              function() {scope.$emit('sf-changed-titlemap', form.key);}
+            );
           });
         }
 

--- a/src/directives/dynamic-choices.js
+++ b/src/directives/dynamic-choices.js
@@ -308,7 +308,6 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
           }
         }
       }
-
       // Otherwise go ahead and populate the title map
       else {
         populateTitleMap();
@@ -316,6 +315,14 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
 
       scope.getItems = function(viewValue) {
         return populateTitleMap(viewValue);
+      }
+
+      // Sigh. Ok, this is terrible.
+      let initialValue = sfSelect(normalizedKey, scope.model);
+      if(initialValue && !attrs.hasOwnProperty('bsSelect')) {
+        ngModel.$setViewValue(initialValue);
+        ngModel.$render();
+        $(element).blur();
       }
     }
   };

--- a/src/directives/dynamic-choices.js
+++ b/src/directives/dynamic-choices.js
@@ -1,3 +1,19 @@
+/* Implementation of the dynamic choices capability
+
+## Referencing other parameters
+During init the choices definition is inspected to see if there are any
+dependencies on other parameters (choices.dependsOn). If so, a watch is created
+for each of them that will fire populateTitleMap whenever the referenced
+parameter changes. The schema-form model will already be updated at this point
+so we can just grab values from it like normal.
+
+## Self-referring choices
+If the choices for an element need to use the current value of the element
+as an input parameter (self-referring), then that needs to be handled slightly
+differently. The current $viewValue (the value type into the element) is already
+passed to populateTitleMap, so we just have to use that instead.
+
+*/
 
 import angular from 'angular';
 
@@ -71,7 +87,7 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
           }
         };
 
-        // Typeaheads need to do some additional parsing and validtating for number types
+        // Typeaheads need to do some additional parsing and validating for number types
         if(form.schema.type.indexOf('integer') !== -1 || form.schema.type.indexOf('number') !== -1) {
           ngModel.$parsers.push(function(value) {
             // See the later parsing comment for why we do this here, but we have to always start as valid
@@ -317,7 +333,12 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
         return populateTitleMap(viewValue);
       }
 
-      // Sigh. Ok, this is terrible.
+      /* Sigh. Ok, this is terrible. This is for the pour-it-again case where
+      a model value was set directly. This does a couple of things:
+      1. Sets the view value to kick the typeahead dropdown population
+      2. Re-renders so the view value shows up in the text box
+      3. Blurs the element to hide the dropdown
+      */
       let initialValue = sfSelect(normalizedKey, scope.model);
       if(initialValue && !attrs.hasOwnProperty('bsSelect')) {
         ngModel.$setViewValue(initialValue);

--- a/src/directives/dynamic-choices.js
+++ b/src/directives/dynamic-choices.js
@@ -290,7 +290,7 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
             // That would be a mistake. We rely on this watch to kick off the initial
             // (on page load) populateTitleMap once all 'dependent' parameters are
             // initialized.
-            populateTitleMap().finally(
+            populateTitleMap(ngModel.$viewValue).finally(
               function() {scope.$emit('sf-changed-titlemap', form.key);}
             );
           });

--- a/src/directives/dynamic-choices.js
+++ b/src/directives/dynamic-choices.js
@@ -13,6 +13,9 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
       form.titleMap = [];
       form.choices = form.choices || {};
 
+      var formKey = form.key;
+      var normalizedKey = sfPath.normalize(formKey);
+
       if(!form.validationMessage) { form.validationMessage = {}; }
       form.validationMessage['anyOf'] = 'Value is not in list of allowed values';
 
@@ -131,7 +134,7 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
           // This is from https://github.com/beer-garden/beer-garden/issues/439 - we need
           // to use the viewValue in that case because the model hasn't been updated yet.
           function getArgValue(field) {
-            if(field == form.key.join('.')) {
+            if(sfPath.normalize(field) == normalizedKey) {
               return viewValue;
             } else {
               return sfSelect(field, scope.model);
@@ -298,7 +301,11 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
         }
 
         for(var i=0; i<form.choices.updateOn.length; i++) {
-          setupWatch(sfPath.normalize(form.choices.updateOn[i]));
+          // Make sure to only set a watch on OTHER fields
+          let normalizedUpdate = sfPath.normalize(form.choices.updateOn[i]);
+          if(normalizedUpdate != normalizedKey) {
+            setupWatch(normalizedUpdate);
+          }
         }
       }
 

--- a/src/templates/typeahead.html
+++ b/src/templates/typeahead.html
@@ -18,7 +18,6 @@
     popover-placement="right"
     popover-trigger="'mouseenter'"
   ></span>
-
   <input
     type="text"
     class="form-control {{form.fieldHtmlClass}}"
@@ -27,7 +26,7 @@
     sf-changed="form"
     schema-validate="form"
     ng-model-options="{ allowInvalid: true }"
-    uib-typeahead="item.value as item.name for item in form.titleMap | filter:{'name': $viewValue}"
+    uib-typeahead="item.value as item.name for item in getItems($viewValue)"
     typeahead-min-length="0"
     placeholder="{{form.placeholder || form.schema.placeholder || ('')}}"
   ></input>


### PR DESCRIPTION
Fixes beer-garden/beer-garden#439, allows using the current value of a parameter as input to it's choices source.

## Test Instructions
- Use the issue/439 branch of the example plugins

A new command has been added to the `dynamic` plugin, `say_day`. This command uses the current value of the `day` parameter as input to the choices command for that parameter.

The choices command is new as well, `days_filter`. This will return a list of the days of the week containing the given input string, *as long as the input string is 2 or more characters.*

To demonstrate the issue, type the string "es" into the `day` parameter typeahead. The typeahead should be displaying the two days that match this string, but the typeahead is not displaying at all.

Typing another character will cause the typeahead to display if the next character matches *both* the list returned by the previous invocation of the choices command *and* the new character. To see how this is problematic, type the character "d" (so now the value should be "esd"). This will result in two options being displayed, which is correct for that input. Now, clear the input control, and type "esz". This will result in no options being presented, which is again correct. However, now highlight the "z" character and type "d" (so the character is replaced in one step). Instead of the two options from earlier there will be no options presented.

This branch corrects those issues. The typeahead options should display the correct options after typing two characters, and switching the "z" to a "d" in the second test case should immediately display the correct options as well.