### PR TITLE
Adding debounce values to choice templates

### DIFF
--- a/src/templates/select.html
+++ b/src/templates/select.html
@@ -27,7 +27,7 @@
       sf-field-model
       sf-changed="form"
       schema-validate="form"
-      ng-model-options="{ allowInvalid: true }"
+      ng-model-options="{ allowInvalid: true, debounce: 500 }"
       ng-disabled="form.disabled"
       data-placeholder="{{form.placeholder || form.schema.placeholder || ('Select One')}}"
       data-placement="{{form.options.placement || 'bottom-left'}}"

--- a/src/templates/typeahead.html
+++ b/src/templates/typeahead.html
@@ -25,7 +25,7 @@
     sf-field-model
     sf-changed="form"
     schema-validate="form"
-    ng-model-options="{ allowInvalid: true }"
+    ng-model-options="{ allowInvalid: true, debounce: 500 }"
     uib-typeahead="item.value as item.name for item in getItems($viewValue)"
     typeahead-min-length="0"
     placeholder="{{form.placeholder || form.schema.placeholder || ('')}}"


### PR DESCRIPTION
Fixes #31 - adds a debounce to the ngModelOptions for dynamic choices templates.

## Test Instructions

1. Using branch issue/439 of the example plugins, run the `dynamic` plugin.
2. Go to the page to run the `say_day` command
3. Open the browser dev tools to the Network tab
4. Start typing. A new request should only be generated after no characters have been typed for half a second.