### PR TITLE
Error indicators no longer show on form load

### DIFF
--- a/src/templates/select.html
+++ b/src/templates/select.html
@@ -10,7 +10,7 @@
   <span
     class="glyphicon glyphicon-info-sign"
     style="cursor: default;"
-    ng-show="form.fetchErrorMessage"
+    ng-if="form.fetchErrorMessage"
     uib-popover="{{form.fetchErrorMessage}}"
     popover-title="Error Populating Choices"
     popover-animation="true"

--- a/src/templates/typeahead.html
+++ b/src/templates/typeahead.html
@@ -11,7 +11,7 @@
   <span
     class="glyphicon glyphicon-info-sign"
     style="cursor: default;"
-    ng-show="form.fetchErrorMessage"
+    ng-if="form.fetchErrorMessage"
     uib-popover="{{form.fetchErrorMessage}}"
     popover-title="Error Populating Choices"
     popover-animation="true"


### PR DESCRIPTION
This fixes #34. Using `ng-if` instead of `ng-show` doesn't cause the element to be rendered before the angular digest cycle can hide it.