### PR TITLE
Adding wait indication when choices are loading

### DIFF
--- a/src/directives/dynamic-choices.js
+++ b/src/directives/dynamic-choices.js
@@ -15,8 +15,6 @@ passed to populateTitleMap, so we just have to use that instead.
 
 */
 
-import angular from 'angular';
-
 dynamicChoicesDirective.$inject = ['$http', '$q', 'filterFilter', 'sfPath', 'sfSelect'];
 export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelect) {
   return {
@@ -28,6 +26,7 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
       var form = scope.form;
       form.titleMap = [];
       form.choices = form.choices || {};
+      form.showSpinner = false;
 
       var formKey = form.key;
       var normalizedKey = sfPath.normalize(formKey);
@@ -130,6 +129,9 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
 
 
       function populateTitleMap(viewValue) {
+        // Show the spinner to indicate loading
+        form.showSpinner = true;
+
         // Invoke whatever method is specified to populate the titleMap
         var promise;
         if(form.choices.titleMap || form.choices.enum) {
@@ -302,6 +304,9 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
 
         form.titleMap = newTitleMap;
 
+        // All done loading so hide the the spinner
+        form.showSpinner = false;
+
         // Make sure that current model is still valid with the new choices
         ngModel.$validate();
 
@@ -310,6 +315,9 @@ export function dynamicChoicesDirective($http, $q, filterFilter, sfPath, sfSelec
 
       function handleError(response) {
         form.fetchErrorMessage = response.message ? response.message : "Couldn't populate choices from " + response.url;
+
+        // All done loading so hide the the spinner
+        form.showSpinner = false;
       }
 
       // If this depends on other fields register a watch on each of them

--- a/src/templates/select.html
+++ b/src/templates/select.html
@@ -18,6 +18,11 @@
     popover-trigger="'mouseenter'"
   ></span>
 
+  <span
+    class="fa fa-spinner fa-pulse animate-fix"
+    ng-if="form.showSpinner"
+  ></span>
+
   <div class="form-group">
 
     <button

--- a/src/templates/select.html
+++ b/src/templates/select.html
@@ -21,6 +21,10 @@
   <span
     class="fa fa-spinner fa-pulse animate-fix"
     ng-if="form.showSpinner"
+    uib-popover="Loading choices"
+    popover-animation="true"
+    popover-placement="right"
+    popover-trigger="'mouseenter'"
   ></span>
 
   <div class="form-group">

--- a/src/templates/typeahead.html
+++ b/src/templates/typeahead.html
@@ -22,6 +22,10 @@
   <span
     class="fa fa-spinner fa-pulse animate-fix"
     ng-if="form.showSpinner"
+    uib-popover="Loading choices"
+    popover-animation="true"
+    popover-placement="right"
+    popover-trigger="'mouseenter'"
   ></span>
 
   <input

--- a/src/templates/typeahead.html
+++ b/src/templates/typeahead.html
@@ -18,6 +18,12 @@
     popover-placement="right"
     popover-trigger="'mouseenter'"
   ></span>
+
+  <span
+    class="fa fa-spinner fa-pulse animate-fix"
+    ng-if="form.showSpinner"
+  ></span>
+
   <input
     type="text"
     class="form-control {{form.fieldHtmlClass}}"


### PR DESCRIPTION
This fixes beer-garden/beer-garden#393. It adds a spinner indicator when choices are being populated.

## Test instructions

1. Run the dynamic plugin
2. Go to the `say_specific_from_command` page
3. You should see a spinner next to the `message` parameter while the choices are being loaded