### PR TITLE
bg-issue #1165 adds support for bytes type

### DIFF
--- a/demo/app.js
+++ b/demo/app.js
@@ -23,6 +23,7 @@ import regularObject from './aspects/regular-object.js';
 import partitionedObject from './aspects/partitioned-object';
 import hiddenFields from './aspects/hidden-fields';
 import fileUpload from './aspects/file-upload';
+import fileUploadBytes from './aspects/file-upload-bytes';
 import dynamicChoices from './aspects/dynamic-choices';
 import complex from './aspects/complex';
 import date from './aspects/date';
@@ -103,6 +104,7 @@ function($scope, $http, $cookies) {
     'Partitioned Object': partitionedObject,
     'Hidden Fields': hiddenFields,
     'File Upload': fileUpload,
+    'File Upload Bytes': fileUploadBytes,
     'Dynamic Choices': dynamicChoices,
     'Complex': complex,
     'Date': date

--- a/demo/aspects/file-upload-bytes.js
+++ b/demo/aspects/file-upload-bytes.js
@@ -1,36 +1,34 @@
 
 var fileUpload = {
   schema: {
-    'image': {
-      title: 'Image file',
+    'bytes_key_optional': {
+      title: 'Bytes Type Optional',
       type: 'file',
-      format: 'base64',
+      format: 'bytes',
       maxSize: '5242880'
     },
-    'images': {
-      type: 'array',
-      maxItems: 2,
-      items: {
-        type: 'file',
-        format: 'base64',
-        maxSize: '5242880',
-        title: 'Image file'
-      }
-    }
+    'bytes_key': {
+      title: 'Bytes Type',
+      type: 'file',
+      format: 'bytes',
+      maxSize: '5242880',
+      required: true
+    },
   },
   form: [
     {
-      key: 'images',
-      title: 'Images upload',
-      description: 'what',
+      key: 'bytes_key_optional',
+      title: 'Bytes type optional',
+      description: 'Upload a file',
       placeholder: 'Click here or drop files to upload'
     },
     {
-      key: 'image',
-      title: 'Image upload',
+      key: 'bytes_key',
+      title: 'Bytes type',
       description: 'Upload a file',
       placeholder: 'Click here or drop files to upload'
-    }
+    },
+
   ]
 };
 

--- a/demo/aspects/file-upload.js
+++ b/demo/aspects/file-upload.js
@@ -16,7 +16,20 @@ var fileUpload = {
         maxSize: '5242880',
         title: 'Image file'
       }
-    }
+    },
+    'bytes_key_optional': {
+      title: 'Bytes Type Optional',
+      type: 'file',
+      format: 'bytes',
+      maxSize: '5242880'
+    },
+    'bytes_key': {
+      title: 'Bytes Type',
+      type: 'file',
+      format: 'bytes',
+      maxSize: '5242880',
+      required: true
+    },
   },
   form: [
     {
@@ -30,7 +43,20 @@ var fileUpload = {
       title: 'Image upload',
       description: 'Upload a file',
       placeholder: 'Click here or drop files to upload'
-    }
+    },
+    {
+      key: 'bytes_key_optional',
+      title: 'Bytes type optional',
+      description: 'Upload a file',
+      placeholder: 'Click here or drop files to upload'
+    },
+    {
+      key: 'bytes_key',
+      title: 'Bytes type',
+      description: 'Upload a file',
+      placeholder: 'Click here or drop files to upload'
+    },
+
   ]
 };
 

--- a/src/addons.js
+++ b/src/addons.js
@@ -8,6 +8,7 @@ import 'eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.css
 
 import { dynamicChoicesDirective } from './directives/dynamic-choices.js';
 import { fileUploadDirective, formatFileSize } from './directives/file-upload';
+import { fileUploadBytesDirective } from './directives/file-upload-bytes';
 import { rawDirective } from './directives/raw.js';
 import { dictionaryDirective } from './directives/dictionary.js';
 import { nullableObjectDirective, nullableObjectPostProcessor } from './directives/nullable-object.js';
@@ -17,6 +18,7 @@ import { dateTimeDirective } from './directives/datetime.js';
 import arrayTemplate from './templates/array.html';
 import accordionTemplate from './templates/accordion.html';
 import fileUploadTemplate from './templates/file-upload.html';
+import fileUploadBytesTemplate from './templates/file-upload-bytes.html';
 import typeaheadTemplate from './templates/typeahead.html';
 import selectTemplate from './templates/select.html';
 import rawTemplate from './templates/raw.html';
@@ -35,6 +37,7 @@ angular.module('beer-garden.addons', ['schemaForm'])
   .directive('raw', rawDirective)
   .directive('dictionary', dictionaryDirective)
   .directive('nullableObject', nullableObjectDirective)
+  .directive('fileUploadBytes', fileUploadBytesDirective)
   .directive('fileUpload', fileUploadDirective)
   .directive('dateTime', dateTimeDirective)
   .run(nullableObjectPostProcessor);
@@ -57,6 +60,9 @@ function addonsConfig(schemaFormProvider, schemaFormDecoratorsProvider, sfBuilde
 
   schemaFormDecoratorsProvider.defineAddOn('bootstrapDecorator',
     'base64file', fileUploadTemplate, stdBuilders);
+
+  schemaFormDecoratorsProvider.defineAddOn('bootstrapDecorator',
+      'bytesFile', fileUploadBytesTemplate, stdBuilders);
 
   schemaFormDecoratorsProvider.defineAddOn('bootstrapDecorator',
     'accordion', accordionTemplate, [sfField, transclusion, condition]);
@@ -103,6 +109,17 @@ function addonsConfig(schemaFormProvider, schemaFormDecoratorsProvider, sfBuilde
     }
   }
   schemaFormProvider.prependRule('file', base64fileRule);
+
+  var bytesFileRule = function(name, schema, options) {
+    if (verifyType('file', schema.type) && schema.format === 'bytes') {
+      var f = schemaFormProvider.stdFormObj(name, schema, options);
+      f.key = options.path;
+      f.type = 'bytesFile';
+      options.lookup[sfPathProvider.stringify(options.path)] = f;
+      return f;
+    }
+  }
+  schemaFormProvider.prependRule('file', bytesFileRule);
 
   var variantRule = function(name, schema, options) {
     if (verifyType('variant', schema.type)) {

--- a/src/directives/file-upload-bytes.js
+++ b/src/directives/file-upload-bytes.js
@@ -1,42 +1,52 @@
 fileUploadBytesDirective.$inject = ['$rootScope'];
+
 function fileUploadBytesDirective($rootScope) {
-  return {
-    restrict: 'A',
-    require: 'ngModel',
-    scope: true,
-    link: function(scope, element, attrs, ngModel) {
+    return {
+        restrict: 'A',
+        require: 'ngModel',
+        scope: true,
+        link: function (scope, element, attrs, ngModel) {
 
-      scope.ngModel = ngModel;
-      scope.key = ngModel.$$scope.getKey()[ngModel.$$scope.getKey().length-1];
-      scope.fileInput = element[0].querySelector('.file-upload-field');
-      scope.inputText = "No File Chosen";
-      scope.fileName = null
+            scope.ngModel = ngModel;
+            scope.key = ngModel.$$scope.getKey()[ngModel.$$scope.getKey().length - 1];
+            scope.fileInput = element[0].querySelector('.file-upload-field');
+            scope.fileName = null;
+            scope.hasFile = false;
 
-      scope.selectedFile = function () {
-        let file = document.getElementById(scope.key).files[0];
-        if (file) {
-          scope.fileName = file.name;
-        } else {
-          scope.fileName = null;
+            scope.selectedFile = function () {
+                let file = document.getElementById(scope.key).files[0];
+                if (file) {
+                    scope.fileName = file.name;
+                    scope.hasFile = true;
+                } else {
+                    scope.fileName = null;
+                    scope.hasFile = false;
+                }
+                scope.validateValue();
+                scope.$apply();
+            }
+
+            scope.removeFile = function () {
+                console.log("testing remove")
+                document.getElementById(scope.key).value = "";
+                scope.hasFile = false;
+                scope.fileName = null;
+                scope.validateValue();
+            }
+
+            scope.validateValue = function () {
+                if (!scope.hasFile && ngModel.$$scope.form.required && !ngModel.$modelValue) {
+                    ngModel.$setValidity('tv4-302', false);
+                } else {
+                    ngModel.$setValidity('tv4-302', true);
+                }
+            }
+
+            scope.$on('schemaFormValidate', function () {
+                scope.validateValue();
+            })
         }
-        scope.validateValue();
-        scope.$apply();
-      }
-
-      scope.validateValue = function () {
-        Object.keys(ngModel.$error).forEach(function(k) {
-          ngModel.$setValidity(k, true);
-        });
-        if (!document.getElementById(scope.key).files[0] && ngModel.$$scope.form.required && !ngModel.$modelValue) {
-          ngModel.$setValidity('tv4-302', false);
-        }
-      }
-      
-      scope.$on('schemaFormValidate', function() {
-        scope.validateValue();
-      })
     }
-  }
 }
 
-export { fileUploadBytesDirective };
+export {fileUploadBytesDirective};

--- a/src/directives/file-upload-bytes.js
+++ b/src/directives/file-upload-bytes.js
@@ -1,0 +1,42 @@
+fileUploadBytesDirective.$inject = ['$rootScope'];
+function fileUploadBytesDirective($rootScope) {
+  return {
+    restrict: 'A',
+    require: 'ngModel',
+    scope: true,
+    link: function(scope, element, attrs, ngModel) {
+
+      scope.ngModel = ngModel;
+      scope.key = ngModel.$$scope.getKey()[ngModel.$$scope.getKey().length-1];
+      scope.fileInput = element[0].querySelector('.file-upload-field');
+      scope.inputText = "No File Chosen";
+      scope.fileName = null
+
+      scope.selectedFile = function () {
+        let file = document.getElementById(scope.key).files[0];
+        if (file) {
+          scope.fileName = file.name;
+        } else {
+          scope.fileName = null;
+        }
+        scope.validateValue();
+        scope.$apply();
+      }
+
+      scope.validateValue = function () {
+        Object.keys(ngModel.$error).forEach(function(k) {
+          ngModel.$setValidity(k, true);
+        });
+        if (!document.getElementById(scope.key).files[0] && ngModel.$$scope.form.required && !ngModel.$modelValue) {
+          ngModel.$setValidity('tv4-302', false);
+        }
+      }
+      
+      scope.$on('schemaFormValidate', function() {
+        scope.validateValue();
+      })
+    }
+  }
+}
+
+export { fileUploadBytesDirective };

--- a/src/templates/file-upload-bytes.html
+++ b/src/templates/file-upload-bytes.html
@@ -1,0 +1,26 @@
+<div
+ class="form-group has-feedback {{form.htmlClass}}"
+ ng-class="{'has-error': form.disableErrorState !== true && hasError(), 'has-success': form.disableSuccessState !== true && hasSuccess()}"
+ file-upload-bytes="form"
+ sf-field-model
+ sf-changed="form"
+ ng-model-options="form.ngModelOptions"
+ >
+
+  <label
+    class="{{form.labelHtmlClass}}"
+    ng-class="{'sr-only': !showTitle()}"
+  >{{form.title}}</label>
+
+ <input class="file-upload-field" ng-hide="true" type="file" id="{{key}}" onchange="angular.element(this).scope().selectedFile()" />
+ <div class="input-group btn btn-default col-xs-12 form-control" ng-click="fileInput.click()">
+  <span class="pull-left">{{fileName || inputText}}</span>
+  <i class="glyphicon glyphicon-upload pull-right"></i>
+
+
+ </div>
+  <div
+    class="help-block"
+    sf-message="form.description">
+  </div>
+</div>

--- a/src/templates/file-upload-bytes.html
+++ b/src/templates/file-upload-bytes.html
@@ -17,8 +17,8 @@
     <div class="input-group col-xs-12">
         <span class="input-group-addon btn btn-default" ng-click="fileInput.click()"><i
                 class="glyphicon glyphicon-upload"></i></span>
-        <input type="text" ng-click="fileInput.click()" class="form-control input-lg btn btn-default"
-               style="text-align:left; padding-left:6px" readonly placeholder="{{fileName || 'Upload File'}}"/>
+        <input type="text" ng-click="fileInput.click()" class="form-control input-lg"
+               readonly placeholder="{{fileName || 'Upload File'}}"/>
         <span class="input-group-btn">
    <button class="btn btn-info input-lg" ng-show="hasFile" type="button" ng-click="removeFile()">
         <i class="glyphicon glyphicon-remove"></i> Remove</button>

--- a/src/templates/file-upload-bytes.html
+++ b/src/templates/file-upload-bytes.html
@@ -1,26 +1,34 @@
 <div
- class="form-group has-feedback {{form.htmlClass}}"
- ng-class="{'has-error': form.disableErrorState !== true && hasError(), 'has-success': form.disableSuccessState !== true && hasSuccess()}"
- file-upload-bytes="form"
- sf-field-model
- sf-changed="form"
- ng-model-options="form.ngModelOptions"
- >
+        class="form-group has-feedback {{form.htmlClass}}"
+        ng-class="{'has-error': form.disableErrorState !== true && hasError(), 'has-success': form.disableSuccessState !== true && hasSuccess()}"
+        file-upload-bytes="form"
+        sf-field-model
+        sf-changed="form"
+        ng-model-options="form.ngModelOptions"
+>
 
-  <label
-    class="{{form.labelHtmlClass}}"
-    ng-class="{'sr-only': !showTitle()}"
-  >{{form.title}}</label>
+    <label
+            class="{{form.labelHtmlClass}}"
+            ng-class="{'sr-only': !showTitle()}"
+    >{{form.title}}</label>
 
- <input class="file-upload-field" ng-hide="true" type="file" id="{{key}}" onchange="angular.element(this).scope().selectedFile()" />
- <div class="input-group btn btn-default col-xs-12 form-control" ng-click="fileInput.click()">
-  <span class="pull-left">{{fileName || inputText}}</span>
-  <i class="glyphicon glyphicon-upload pull-right"></i>
-
-
- </div>
-  <div
-    class="help-block"
-    sf-message="form.description">
-  </div>
+    <input class="file-upload-field" ng-hide="true" type="file" id="{{key}}"
+           onchange="angular.element(this).scope().selectedFile()"/>
+    <div class="input-group col-xs-12">
+        <span class="input-group-addon btn btn-default" ng-click="fileInput.click()"><i
+                class="glyphicon glyphicon-upload"></i></span>
+        <input type="text" ng-click="fileInput.click()" class="form-control input-lg btn btn-default"
+               style="text-align:left; padding-left:6px" readonly placeholder="{{fileName || 'Upload File'}}"/>
+        <span class="input-group-btn">
+   <button class="btn btn-info input-lg" ng-show="hasFile" type="button" ng-click="removeFile()">
+        <i class="glyphicon glyphicon-remove"></i> Remove</button>
+      <button class="btn btn-primary input-lg" ng-click="fileInput.click()" ng-show="!hasFile"
+              ng-disabled="form.readonly" type="button">
+        <i class="glyphicon glyphicon-search"></i> Browse</button>
+    </span>
+    </div>
+    <div
+            class="help-block"
+            sf-message="form.description">
+    </div>
 </div>


### PR DESCRIPTION
Adds a custom addon for selecting a file for `file` types with a bytes format.

Can test by running `npm install` then `npm run serve` and going to file upload section and looking at the part of form with bytes title, or following instructions in PR https://github.com/beer-garden/beer-garden/pull/1195